### PR TITLE
Parse variables and operationName for server example

### DIFF
--- a/internal/exec/scalar.go
+++ b/internal/exec/scalar.go
@@ -21,11 +21,19 @@ var intScalar = &scalar{
 	name:        "Int",
 	reflectType: reflect.TypeOf(int32(0)),
 	coerceInput: func(input interface{}) (interface{}, error) {
-		i := input.(int)
-		if i < math.MinInt32 || i > math.MaxInt32 {
-			return nil, fmt.Errorf("not a 32-bit integer: %d", i)
+		switch input.(type) {
+		case int:
+			i := input.(int)
+			if i < math.MinInt32 || i > math.MaxInt32 {
+				return nil, fmt.Errorf("not a 32-bit integer: %d", i)
+			}
+			return int32(i), nil
+		case float64:
+			i := input.(float64)
+			return int32(i), nil
+		default:
+			return nil, fmt.Errorf("Int cannot use type: %s", reflect.TypeOf(input))
 		}
-		return int32(i), nil
 	},
 }
 var floatScalar = &scalar{


### PR DESCRIPTION
Using the mutation and variables from http://graphql.org/learn/queries/#mutations in GraphiQL wasn't working in the example server. 

Variables (logging the type, key, and value from json.Unmarshal):
```
type: string k: ep v: JEDI
type: map[string]interface {} k: review v: map[stars:5 commentary:This is a great movie!]
--type: float64 k: stars v: 5
--type: string k: commentary v: This is a great movie!
```

`json.Unmarshal`defaults to float64 for the type of stars, so it was causing a panic:

```
2016/11/05 15:54:14 http: panic serving [::1]:62941: interface conversion: interface is float64, not int
```

So I adjusted `internal/exec/scalar.go` to cast `float64` to `int32`, so the example will work with the way I've unmarshaled the json. Casting from float64 to int32 seems harmless since the type was specified as `Int` in graphql, but perhaps there is a better way. 