### PR TITLE
Fix for ServeHTTP not handling strings for 'variable' variable

### DIFF
--- a/relay/relay.go
+++ b/relay/relay.go
@@ -50,16 +50,28 @@ type Handler struct {
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var params struct {
-		Query         string                 `json:"query"`
-		OperationName string                 `json:"operationName"`
-		Variables     map[string]interface{} `json:"variables"`
+		Query         string `json:"query"`
+		OperationName string `json:"operationName"`
+		Variables     string `json:"variables"`
 	}
+
 	if err := json.NewDecoder(r.Body).Decode(&params); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	response := h.Schema.Exec(r.Context(), params.Query, params.OperationName, params.Variables)
+	var parsedVariables map[string]interface{}
+
+	if len(params.Variables) > 0 {
+		if err := json.Unmarshal([]byte(params.Variables), &parsedVariables); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+	} else {
+		parsedVariables = make(map[string]interface{})
+	}
+
+	response := h.Schema.Exec(r.Context(), params.Query, params.OperationName, parsedVariables)
 	responseJSON, err := json.Marshal(response)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -55,12 +55,18 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Variables     string `json:"variables"`
 	}
 
-	if err := json.NewDecoder(r.Body).Decode(&params); err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-
 	var parsedVariables map[string]interface{}
+
+	if r.Method == http.MethodGet {
+		params.Query = r.URL.Query().Get("query")
+		params.Variables = r.URL.Query().Get("variables")
+		params.OperationName = r.URL.Query().Get("operationName")
+	} else {
+		if err := json.NewDecoder(r.Body).Decode(&params); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+	}
 
 	if len(params.Variables) > 0 {
 		if err := json.Unmarshal([]byte(params.Variables), &parsedVariables); err != nil {


### PR DESCRIPTION
Hi,

Testing out a graphql endpoint using neelance/graphql-go produced errors when using https://github.com/skevy/graphiql-app, but not another Chrome graphiql extension.  The difference was that the former would send "" for variables.  I discovered that even when I added variables in, the server would produce errors.

With this commit, I'm able to leave variables empty (with "" or null) or include them, and the server will parse them correctly.

Also added checks for request type, and grab the values from the appropriate place depending on whether the request is GET or not.