### PR TITLE
implement sql.Scanner and driver.Value for graphql.ID type

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -6,6 +6,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"fmt"
+	"strconv"
 
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
@@ -40,6 +41,12 @@ func (id *ID) Scan(src interface{}) error {
 	switch t := src.(type) {
 	case string:
 		*id = ID(t)
+	case int64:
+		*id = ID(strconv.FormatInt(t, 10))
+	case []byte:
+		*id = ID(t)
+	case nil:
+		// do nothing
 	default:
 		return fmt.Errorf("wrong type")
 	}

--- a/graphql.go
+++ b/graphql.go
@@ -2,6 +2,8 @@ package graphql
 
 import (
 	"context"
+	"database/sql"
+	"database/sql/driver"
 	"encoding/json"
 	"fmt"
 
@@ -27,6 +29,26 @@ const OpenTracingTagArgsPrefix = "graphql.args."
 const OpenTracingTagError = "graphql.error"
 
 type ID string
+
+// compile time check
+var (
+	_ sql.Scanner   = (*ID)(nil)
+	_ driver.Valuer = (*ID)(nil)
+)
+
+func (id *ID) Scan(src interface{}) error {
+	switch t := src.(type) {
+	case string:
+		*id = ID(t)
+	default:
+		return fmt.Errorf("wrong type")
+	}
+	return nil
+}
+
+func (id ID) Value() (driver.Value, error) {
+	return string(id), nil
+}
 
 func ParseSchema(schemaString string, resolver interface{}) (*Schema, error) {
 	b := New()


### PR DESCRIPTION
This makes `graphql.ID` type implement [sql.Scanner](https://golang.org/pkg/database/sql/#Scanner) and [driver.Valuer](https://golang.org/pkg/database/sql/driver/#Valuer). This simplifies the data structures that I'm using so that they can implement the types that graphql likes but can also be marshaled into the DB.  