### PR TITLE
POC: custom error handlers

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -3,8 +3,9 @@ package errors
 import "fmt"
 
 type QueryError struct {
-	Message   string      `json:"message"`
-	Locations []*Location `json:"locations,omitempty"`
+	Message       string      `json:"message"`
+	Locations     []*Location `json:"locations,omitempty"`
+	ResolverError error       `json:"-"`
 }
 
 type Location struct {

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -554,7 +554,9 @@ func (e *fieldExec) execField(ctx context.Context, r *request, f *query.Field, r
 	result, err := e.execField2(spanCtx, r, f, resolver, span)
 
 	if err != nil {
-		r.addError(errors.Errorf("%s", err))
+		queryError := errors.Errorf("%s", err)
+		queryError.ResolverError = err
+		r.addError(queryError)
 		addResult(f.Alias, nil) // TODO handle non-nil
 
 		ext.Error.Set(span, true)


### PR DESCRIPTION
This proof of concept will likely need changes before it can be merged but I hope it can serve as a starting point for a conversation around how we can elegantly handle errors in this library.

This change gives users an optional hook to handle errors. Access to this hook opens up the door for several use cases:

-  Send more information rich errors to the client (related to #37) like sending error codes or other data related to error.
- Single place to filter out "non-user-safe" errors from being sent to the client.
- Integrate/send errors created in my resolves or graphql to a logging/monitoring service.

One benefit of this approach is that it is non-breaking. Users are able to "opt-in" when needed.