### PR TITLE
Respect Context Cancellation and Deadline

### DIFF
--- a/graphql_test.go
+++ b/graphql_test.go
@@ -1478,7 +1478,8 @@ func TestContextDeadline(t *testing.T) {
 	`
 
 	timeout := time.Millisecond * 100
-	acceptableDelay := time.Millisecond * 5
+	// We accept that we wont quite exit exactly when the context deadline is exceeded
+	acceptableDelay := time.Millisecond * 20
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -1451,3 +1451,42 @@ func TestInput(t *testing.T) {
 		},
 	})
 }
+
+type sleepyResolver struct {
+	SleepFor time.Duration
+}
+
+func (r *sleepyResolver) Hello() string {
+	time.Sleep(r.SleepFor)
+	return "Hello world!"
+}
+
+func TestContextDeadline(t *testing.T) {
+	s := graphql.MustParseSchema(`
+		schema {
+			query: Query
+		}
+		
+		type Query {
+			hello: String!
+		}
+	`, &sleepyResolver{SleepFor: time.Second * 2})
+	q := `
+	{
+		hello
+	}
+	`
+
+	timeout := time.Millisecond * 100
+	acceptableDelay := time.Millisecond * 5
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	startTime := time.Now()
+	_ = s.Exec(ctx, q, "", nil)
+	duration := time.Since(startTime)
+
+	if duration > timeout+acceptableDelay {
+		t.Errorf("expected exec to be cancelled after %s, but instead took %s", timeout, duration)
+	}
+}


### PR DESCRIPTION
Points to note:
* `ErrContextDeadlineExceeded` is exposed so that the error message can be customised
* Do we need to distinguish between a context cancel and a context deadline exceeded?
* Increases test suite run time by 100ms - perhaps this test should be run in parallel?
* Currently doesn't stop nested resolve methods from being started, even after the context is cancelled, I will look to improve this either now or in another PR.

Feedback much appreciated.

Fixes #61