### PR TITLE
remove default param on deprecated directive fixes #65

### DIFF
--- a/graphql_test.go
+++ b/graphql_test.go
@@ -512,7 +512,7 @@ func TestDeprecatedDirective(t *testing.T) {
 						],
 						"allFields": [
 							{ "name": "a", "isDeprecated": false, "deprecationReason": null },
-							{ "name": "b", "isDeprecated": true, "deprecationReason": "No longer supported" },
+							{ "name": "b", "isDeprecated": true, "deprecationReason": null },
 							{ "name": "c", "isDeprecated": true, "deprecationReason": "We don't like it" }
 						]
 					}
@@ -556,7 +556,7 @@ func TestDeprecatedDirective(t *testing.T) {
 						],
 						"allEnumValues": [
 							{ "name": "A", "isDeprecated": false, "deprecationReason": null },
-							{ "name": "B", "isDeprecated": true, "deprecationReason": "No longer supported" },
+							{ "name": "B", "isDeprecated": true, "deprecationReason": null },
 							{ "name": "C", "isDeprecated": true, "deprecationReason": "We don't like it" }
 						]
 					}

--- a/internal/schema/meta.go
+++ b/internal/schema/meta.go
@@ -43,7 +43,7 @@ var metaSrc = `
 		# Explains why this element was deprecated, usually also including a suggestion
 		# for how to access supported similar data. Formatted in
 		# [Markdown](https://daringfireball.net/projects/markdown/).
-		reason: String = "No longer supported"
+		reason: String
 	) on FIELD_DEFINITION | ENUM_VALUE
 
 	# A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.

--- a/introspection/introspection.go
+++ b/introspection/introspection.go
@@ -232,8 +232,10 @@ func (r *Field) DeprecationReason() *string {
 	if !ok {
 		return nil
 	}
-	reason := args["reason"].(string)
-	return &reason
+	if reason, ok := args["reason"].(string); ok {
+		return &reason
+	}
+	return nil
 }
 
 type InputValue struct {
@@ -288,8 +290,10 @@ func (r *EnumValue) DeprecationReason() *string {
 	if !ok {
 		return nil
 	}
-	reason := args["reason"].(string)
-	return &reason
+	if reason, ok := args["reason"].(string); ok {
+		return &reason
+	}
+	return nil
 }
 
 type Directive struct {


### PR DESCRIPTION
I'm not sure why, but for some reason the Graphiql parser did not like the default value here.