### PR TITLE
implement user defined logger (with sensible defaults)

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -1,0 +1,23 @@
+package log
+
+import (
+	"context"
+	"log"
+	"runtime"
+)
+
+// Logger is the interface used to log panics that occur durring query execution. It is setable via graphql.ParseSchema
+type Logger interface {
+	LogPanic(ctx context.Context, value interface{})
+}
+
+// DefaultLogger is the default logger used to log panics that occur durring query execution
+type DefaultLogger struct{}
+
+// LogPanic is used to log recovered panic values that occur durring query execution
+func (l *DefaultLogger) LogPanic(_ context.Context, value interface{}) {
+	const size = 64 << 10
+	buf := make([]byte, size)
+	buf = buf[:runtime.Stack(buf, false)]
+	log.Printf("graphql: panic occurred: %v\n%s", value, buf)
+}


### PR DESCRIPTION
This allows users to implement their own logger for when a panic is received during query execution. My use case is that I have implemented a custom logger (i.e. sends logs to logging service) and I would like the  graphql panics to show there when they occur.

This PR introduces no breaking changes but allows users to "opt in" to implementing their own logger if they choose to. Otherwise, everything behaves as it did before.