### PR TITLE
Add supports for snake case

### DIFF
--- a/graphql_test.go
+++ b/graphql_test.go
@@ -38,8 +38,8 @@ func (r *helloSnakeResolver2) HelloHTML(ctx context.Context) (string, error) {
 	return "Hello snake!", nil
 }
 
-func (r *helloSnakeResolver2) SayHello(ctx context.Context, args *struct{ FullName string }) string {
-	return "Hello " + args.FullName + "!"
+func (r *helloSnakeResolver2) SayHello(ctx context.Context, args *struct{ FullName string }) (string, error) {
+	return "Hello " + args.FullName + "!", nil
 }
 
 type theNumberResolver struct {

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -22,6 +22,26 @@ func (r *helloWorldResolver2) Hello(ctx context.Context) (string, error) {
 	return "Hello world!", nil
 }
 
+type helloSnakeResolver1 struct{}
+
+func (r *helloSnakeResolver1) HelloHTML() string {
+	return "Hello snake!"
+}
+
+func (r *helloSnakeResolver1) SayHello(args *struct{ FullName string }) string {
+	return "Hello " + args.FullName + "!"
+}
+
+type helloSnakeResolver2 struct{}
+
+func (r *helloSnakeResolver2) HelloHTML(ctx context.Context) (string, error) {
+	return "Hello snake!", nil
+}
+
+func (r *helloSnakeResolver2) SayHello(ctx context.Context, args *struct{ FullName string }) string {
+	return "Hello " + args.FullName + "!"
+}
+
 type theNumberResolver struct {
 	number int32
 }
@@ -85,6 +105,102 @@ func TestHelloWorld(t *testing.T) {
 			ExpectedResult: `
 				{
 					"hello": "Hello world!"
+				}
+			`,
+		},
+	})
+}
+
+func TestHelloSnake(t *testing.T) {
+	gqltesting.RunTests(t, []*gqltesting.Test{
+		{
+			Schema: graphql.MustParseSchema(`
+				schema {
+					query: Query
+				}
+
+				type Query {
+					hello_html: String!
+				}
+			`, &helloSnakeResolver1{}),
+			Query: `
+				{
+					hello_html
+				}
+			`,
+			ExpectedResult: `
+				{
+					"hello_html": "Hello snake!"
+				}
+			`,
+		},
+
+		{
+			Schema: graphql.MustParseSchema(`
+				schema {
+					query: Query
+				}
+
+				type Query {
+					hello_html: String!
+				}
+			`, &helloSnakeResolver2{}),
+			Query: `
+				{
+					hello_html
+				}
+			`,
+			ExpectedResult: `
+				{
+					"hello_html": "Hello snake!"
+				}
+			`,
+		},
+	})
+}
+
+func TestHelloSnakeArguments(t *testing.T) {
+	gqltesting.RunTests(t, []*gqltesting.Test{
+		{
+			Schema: graphql.MustParseSchema(`
+				schema {
+					query: Query
+				}
+
+				type Query {
+					say_hello(full_name: String!): String!
+				}
+			`, &helloSnakeResolver1{}),
+			Query: `
+				{
+					say_hello(full_name: "Rob Pike")
+				}
+			`,
+			ExpectedResult: `
+				{
+					"say_hello": "Hello Rob Pike!"
+				}
+			`,
+		},
+
+		{
+			Schema: graphql.MustParseSchema(`
+				schema {
+					query: Query
+				}
+
+				type Query {
+					say_hello(full_name: String!): String!
+				}
+			`, &helloSnakeResolver2{}),
+			Query: `
+				{
+					say_hello(full_name: "Rob Pike")
+				}
+			`,
+			ExpectedResult: `
+				{
+					"say_hello": "Hello Rob Pike!"
 				}
 			`,
 		},

--- a/internal/exec/resolvable/packer.go
+++ b/internal/exec/resolvable/packer.go
@@ -130,8 +130,11 @@ func (b *execBuilder) makeStructPacker(values common.InputValueList, typ reflect
 	var fields []*structPackerField
 	for _, v := range values {
 		fe := &structPackerField{field: v}
+		fx := func(n string) bool {
+			return strings.EqualFold(n, v.Name.Name) || strings.EqualFold(camelize(n), camelize(v.Name.Name))
+		}
 
-		sf, ok := structType.FieldByNameFunc(func(n string) bool { return strings.EqualFold(n, v.Name.Name) })
+		sf, ok := structType.FieldByNameFunc(fx)
 		if !ok {
 			return nil, fmt.Errorf("missing argument %q", v.Name)
 		}

--- a/internal/exec/resolvable/packer.go
+++ b/internal/exec/resolvable/packer.go
@@ -131,7 +131,7 @@ func (b *execBuilder) makeStructPacker(values common.InputValueList, typ reflect
 	for _, v := range values {
 		fe := &structPackerField{field: v}
 		fx := func(n string) bool {
-			return strings.EqualFold(n, v.Name.Name) || strings.EqualFold(stripUnderscore(n), stripUnderscore(v.Name.Name))
+			return strings.EqualFold(stripUnderscore(n), stripUnderscore(v.Name.Name))
 		}
 
 		sf, ok := structType.FieldByNameFunc(fx)

--- a/internal/exec/resolvable/packer.go
+++ b/internal/exec/resolvable/packer.go
@@ -131,7 +131,7 @@ func (b *execBuilder) makeStructPacker(values common.InputValueList, typ reflect
 	for _, v := range values {
 		fe := &structPackerField{field: v}
 		fx := func(n string) bool {
-			return strings.EqualFold(n, v.Name.Name) || strings.EqualFold(camelize(n), camelize(v.Name.Name))
+			return strings.EqualFold(n, v.Name.Name) || strings.EqualFold(stripUnderscore(n), stripUnderscore(v.Name.Name))
 		}
 
 		sf, ok := structType.FieldByNameFunc(fx)

--- a/internal/exec/resolvable/resolvable.go
+++ b/internal/exec/resolvable/resolvable.go
@@ -333,7 +333,7 @@ func (b *execBuilder) makeFieldExec(typeName string, f *schema.Field, m reflect.
 
 func findMethod(t reflect.Type, name string) int {
 	for i := 0; i < t.NumMethod(); i++ {
-		if strings.EqualFold(name, t.Method(i).Name) || strings.EqualFold(stripUnderscore(name), stripUnderscore(t.Method(i).Name)) {
+		if strings.EqualFold(stripUnderscore(name), stripUnderscore(t.Method(i).Name)) {
 			return i
 		}
 	}

--- a/internal/exec/resolvable/resolvable.go
+++ b/internal/exec/resolvable/resolvable.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"unicode"
 
 	"github.com/neelance/graphql-go/internal/common"
 	"github.com/neelance/graphql-go/internal/schema"
@@ -333,7 +334,7 @@ func (b *execBuilder) makeFieldExec(typeName string, f *schema.Field, m reflect.
 
 func findMethod(t reflect.Type, name string) int {
 	for i := 0; i < t.NumMethod(); i++ {
-		if strings.EqualFold(name, t.Method(i).Name) {
+		if strings.EqualFold(name, t.Method(i).Name) || strings.EqualFold(camelize(name), camelize(t.Method(i).Name)) {
 			return i
 		}
 	}
@@ -345,4 +346,70 @@ func unwrapNonNull(t common.Type) (common.Type, bool) {
 		return nn.OfType, true
 	}
 	return t, false
+}
+
+func camelize(s string) string {
+	var ws string
+
+	for _, w := range strings.Split(s, "_") {
+		if len(w) == 0 {
+			continue
+		}
+
+		if u := strings.ToUpper(w); commonInitialisms[u] {
+			ws += u
+			continue
+		}
+
+		z := []rune(w)
+		z[0] = unicode.ToUpper(z[0])
+		ws += string(z)
+	}
+
+	return ws
+}
+
+// commonInitialisms is a set of common initialisms.
+// Only add entries that are highly unlikely to be non-initialisms.
+// For instance, "ID" is fine (Freudian code is rare), but "AND" is not.
+// Taken from: https://github.com/golang/lint/blob/206c0f020eba0f7fbcfbc467a5eb808037df2ed6/lint.go#L731
+var commonInitialisms = map[string]bool{
+	"ACL":   true,
+	"API":   true,
+	"ASCII": true,
+	"CPU":   true,
+	"CSS":   true,
+	"DNS":   true,
+	"EOF":   true,
+	"GUID":  true,
+	"HTML":  true,
+	"HTTP":  true,
+	"HTTPS": true,
+	"ID":    true,
+	"IP":    true,
+	"JSON":  true,
+	"LHS":   true,
+	"QPS":   true,
+	"RAM":   true,
+	"RHS":   true,
+	"RPC":   true,
+	"SLA":   true,
+	"SMTP":  true,
+	"SQL":   true,
+	"SSH":   true,
+	"TCP":   true,
+	"TLS":   true,
+	"TTL":   true,
+	"UDP":   true,
+	"UI":    true,
+	"UID":   true,
+	"UUID":  true,
+	"URI":   true,
+	"URL":   true,
+	"UTF8":  true,
+	"VM":    true,
+	"XML":   true,
+	"XMPP":  true,
+	"XSRF":  true,
+	"XSS":   true,
 }

--- a/internal/exec/resolvable/resolvable.go
+++ b/internal/exec/resolvable/resolvable.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
-	"unicode"
 
 	"github.com/neelance/graphql-go/internal/common"
 	"github.com/neelance/graphql-go/internal/schema"
@@ -334,7 +333,7 @@ func (b *execBuilder) makeFieldExec(typeName string, f *schema.Field, m reflect.
 
 func findMethod(t reflect.Type, name string) int {
 	for i := 0; i < t.NumMethod(); i++ {
-		if strings.EqualFold(name, t.Method(i).Name) || strings.EqualFold(camelize(name), camelize(t.Method(i).Name)) {
+		if strings.EqualFold(name, t.Method(i).Name) || strings.EqualFold(stripUnderscore(name), stripUnderscore(t.Method(i).Name)) {
 			return i
 		}
 	}
@@ -348,68 +347,6 @@ func unwrapNonNull(t common.Type) (common.Type, bool) {
 	return t, false
 }
 
-func camelize(s string) string {
-	var ws string
-
-	for _, w := range strings.Split(s, "_") {
-		if len(w) == 0 {
-			continue
-		}
-
-		if u := strings.ToUpper(w); commonInitialisms[u] {
-			ws += u
-			continue
-		}
-
-		z := []rune(w)
-		z[0] = unicode.ToUpper(z[0])
-		ws += string(z)
-	}
-
-	return ws
-}
-
-// commonInitialisms is a set of common initialisms.
-// Only add entries that are highly unlikely to be non-initialisms.
-// For instance, "ID" is fine (Freudian code is rare), but "AND" is not.
-// Taken from: https://github.com/golang/lint/blob/206c0f020eba0f7fbcfbc467a5eb808037df2ed6/lint.go#L731
-var commonInitialisms = map[string]bool{
-	"ACL":   true,
-	"API":   true,
-	"ASCII": true,
-	"CPU":   true,
-	"CSS":   true,
-	"DNS":   true,
-	"EOF":   true,
-	"GUID":  true,
-	"HTML":  true,
-	"HTTP":  true,
-	"HTTPS": true,
-	"ID":    true,
-	"IP":    true,
-	"JSON":  true,
-	"LHS":   true,
-	"QPS":   true,
-	"RAM":   true,
-	"RHS":   true,
-	"RPC":   true,
-	"SLA":   true,
-	"SMTP":  true,
-	"SQL":   true,
-	"SSH":   true,
-	"TCP":   true,
-	"TLS":   true,
-	"TTL":   true,
-	"UDP":   true,
-	"UI":    true,
-	"UID":   true,
-	"UUID":  true,
-	"URI":   true,
-	"URL":   true,
-	"UTF8":  true,
-	"VM":    true,
-	"XML":   true,
-	"XMPP":  true,
-	"XSRF":  true,
-	"XSS":   true,
+func stripUnderscore(s string) string {
+	return strings.Replace(s, "_", "", -1)
 }


### PR DESCRIPTION
Most API from Rails backend use snake_case for the fields and arguments naming. This PR automatically map snake_case name to proper name in Go.