### PR TITLE
Add support for Get prefix on resolver Methods (gogoproto Getters).

### DIFF
--- a/graphql_test.go
+++ b/graphql_test.go
@@ -42,6 +42,27 @@ func (r *helloSnakeResolver2) SayHello(ctx context.Context, args *struct{ FullNa
 	return "Hello " + args.FullName + "!", nil
 }
 
+type helloGetResolver1 struct{}
+
+func (r *helloGetResolver1) GetHelloHTML() string {
+	return "Hello snake!"
+}
+
+func (r *helloGetResolver1) GetSayHello(args *struct{ FullName string }) string {
+	return "Hello " + args.FullName + "!"
+}
+
+type helloGetResolver2 struct {
+}
+
+func (r *helloGetResolver2) GetHelloHTML(ctx context.Context) (string, error) {
+	return "Hello snake!", nil
+}
+
+func (r *helloGetResolver2) GetSayHello(ctx context.Context, args *struct{ FullName string }) (string, error) {
+	return "Hello " + args.FullName + "!", nil
+}
+
 type theNumberResolver struct {
 	number int32
 }
@@ -193,6 +214,102 @@ func TestHelloSnakeArguments(t *testing.T) {
 					say_hello(full_name: String!): String!
 				}
 			`, &helloSnakeResolver2{}),
+			Query: `
+				{
+					say_hello(full_name: "Rob Pike")
+				}
+			`,
+			ExpectedResult: `
+				{
+					"say_hello": "Hello Rob Pike!"
+				}
+			`,
+		},
+	})
+}
+
+func TestGetMethods(t *testing.T) {
+	gqltesting.RunTests(t, []*gqltesting.Test{
+		{
+			Schema: graphql.MustParseSchema(`
+				schema {
+					query: Query
+				}
+
+				type Query {
+					hello_html: String!
+				}
+			`, &helloGetResolver2{}),
+			Query: `
+				{
+					hello_html
+				}
+			`,
+			ExpectedResult: `
+				{
+					"hello_html": "Hello snake!"
+				}
+			`,
+		},
+
+		{
+			Schema: graphql.MustParseSchema(`
+				schema {
+					query: Query
+				}
+
+				type Query {
+					hello_html: String!
+				}
+			`, &helloGetResolver2{}),
+			Query: `
+				{
+					hello_html
+				}
+			`,
+			ExpectedResult: `
+				{
+					"hello_html": "Hello snake!"
+				}
+			`,
+		},
+	})
+}
+
+func TestHelloGetArguments(t *testing.T) {
+	gqltesting.RunTests(t, []*gqltesting.Test{
+		{
+			Schema: graphql.MustParseSchema(`
+				schema {
+					query: Query
+				}
+
+				type Query {
+					say_hello(full_name: String!): String!
+				}
+			`, &helloGetResolver1{}),
+			Query: `
+				{
+					say_hello(full_name: "Rob Pike")
+				}
+			`,
+			ExpectedResult: `
+				{
+					"say_hello": "Hello Rob Pike!"
+				}
+			`,
+		},
+
+		{
+			Schema: graphql.MustParseSchema(`
+				schema {
+					query: Query
+				}
+
+				type Query {
+					say_hello(full_name: String!): String!
+				}
+			`, &helloGetResolver1{}),
 			Query: `
 				{
 					say_hello(full_name: "Rob Pike")

--- a/internal/exec/resolvable/packer.go
+++ b/internal/exec/resolvable/packer.go
@@ -131,7 +131,7 @@ func (b *execBuilder) makeStructPacker(values common.InputValueList, typ reflect
 	for _, v := range values {
 		fe := &structPackerField{field: v}
 		fx := func(n string) bool {
-			return strings.EqualFold(stripUnderscore(n), stripUnderscore(v.Name.Name))
+			return strings.EqualFold(stripGetPrefixAndUnderscore(n), stripUnderscore(v.Name.Name))
 		}
 
 		sf, ok := structType.FieldByNameFunc(fx)

--- a/internal/exec/resolvable/resolvable.go
+++ b/internal/exec/resolvable/resolvable.go
@@ -333,7 +333,7 @@ func (b *execBuilder) makeFieldExec(typeName string, f *schema.Field, m reflect.
 
 func findMethod(t reflect.Type, name string) int {
 	for i := 0; i < t.NumMethod(); i++ {
-		if strings.EqualFold(stripUnderscore(name), stripUnderscore(t.Method(i).Name)) {
+		if strings.EqualFold(stripUnderscore(name), stripGetPrefixAndUnderscore(t.Method(i).Name)) {
 			return i
 		}
 	}
@@ -345,6 +345,13 @@ func unwrapNonNull(t common.Type) (common.Type, bool) {
 		return nn.OfType, true
 	}
 	return t, false
+}
+
+func stripGetPrefixAndUnderscore(s string) string {
+	if strings.HasPrefix(s, "Get") {
+		s = s[3:]
+	}
+	return stripUnderscore(s)
 }
 
 func stripUnderscore(s string) string {


### PR DESCRIPTION
I'm quite desperate to use this codebase but I am having quite a hard time. I have a sprawling tree of complex mutations where each node follows a very similar structure -- I can't leverage this till custom resolvers are in. It took me 700 lines and a lot of tedium just to bootstrap a simple toy/stub version of  our model . In reality the model is much more complex with 2-4 DTO's in use in the Input and Output position per node. 

I'm using the SnakeCase patch as a hack to have the DTOs work as input types and type resolvers --i.e.., `Name_()` for the types. This only aids marginally.

The Project has the Kubernetes go2idl code generation infrastructure in place to generate proto DTOs -- gogoproto can be configured to generate Get methods. If I had this I could generate and orchestrate proto DTOs this would make things more manageable. 

p.s., I am a fan of the hand written schema approach -- But I also really desperately need custom resolvers for this application. 