### PR TITLE
Fix panic when resolver is not a pointer

### DIFF
--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -203,7 +203,7 @@ func (r *Request) execSelectionSet(ctx context.Context, sels []selected.Selectio
 	t, nonNull := unwrapNonNull(typ)
 	switch t := t.(type) {
 	case *schema.Object, *schema.Interface, *schema.Union:
-		if resolver.IsNil() {
+		if resolver.Kind() == reflect.Ptr && resolver.IsNil() {
 			if nonNull {
 				panic(errors.Errorf("got nil for non-null %q", t))
 			}


### PR DESCRIPTION
I ran into a panic when I had a non-nullable object on this line. Because the reflect type is struct and not `reflect.Ptr`, `resolver.IsNil()` panics.

I'm not sure why it matched the case, and I wasn't sure how to add a test for this case.