### PR TITLE
Warn if an interface's resolver has a ToTYPE implementation that does not return two values.

### DIFF
--- a/internal/exec/resolvable/resolvable.go
+++ b/internal/exec/resolvable/resolvable.go
@@ -255,6 +255,9 @@ func (b *execBuilder) makeObjectExec(typeName string, fields schema.FieldList, p
 		if methodIndex == -1 {
 			return nil, fmt.Errorf("%s does not resolve %q: missing method %q to convert to %q", resolverType, typeName, "to"+impl.Name, impl.Name)
 		}
+		if resolverType.Method(methodIndex).Type.NumOut() != 2 {
+			return nil, fmt.Errorf("%s does not resolve %q: method %q should return a value and a bool indicating success", resolverType, typeName, "to"+impl.Name)
+		}
 		a := &TypeAssertion{
 			MethodIndex: methodIndex,
 		}


### PR DESCRIPTION
Currently this instead crashes fairly inscrutably at runtime here: https://github.com/neelance/graphql-go/blob/master/internal/exec/exec.go#L117

An alternate fix would be to check ```len(out)``` there and perhaps rely on ```out[0]``` being nil to ```continue``` if there's only one return value.