### PR TITLE
fix panic when variable name not declared

### DIFF
--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -508,7 +508,7 @@ func validateLiteral(c *opContext, l common.Literal) {
 func validateValueType(c *opContext, v common.Literal, t common.Type) (bool, string) {
 	if v, ok := v.(*common.Variable); ok {
 		for _, op := range c.ops {
-			if v2 := op.Vars.Get(v.Name); v != nil {
+			if v2 := op.Vars.Get(v.Name); v != nil && v2 != nil {
 				t2, err := common.ResolveType(v2.Type, c.schema.Resolve)
 				if _, ok := t2.(*common.NonNull); !ok && v2.Default != nil {
 					t2 = &common.NonNull{OfType: t2}


### PR DESCRIPTION
I was getting a panic when I misnamed a variable (typo). This prevents that panic. 

Example query that would panic:
```graphql
query HeroNameAndFriends($e: Episode) {
     hero(episode: $episode) {
        name
    }
}
```

Now it just gives the error that the variable was never defined. 
