### PR TITLE
Allow custom scalars as input arguments

### DIFF
--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -607,6 +607,9 @@ func validateBasicLit(v *common.BasicLit, t common.Type) bool {
 			return v.Type == scanner.Ident && (v.Text == "true" || v.Text == "false")
 		case "ID":
 			return v.Type == scanner.Int || v.Type == scanner.String
+		default:
+			//TODO: Type-check against expected type by Unmarshalling
+			return true
 		}
 
 	case *schema.Enum:

--- a/time.go
+++ b/time.go
@@ -27,6 +27,9 @@ func (t *Time) UnmarshalGraphQL(input interface{}) error {
 	case int:
 		t.Time = time.Unix(int64(input), 0)
 		return nil
+	case float64:
+		t.Time = time.Unix(int64(input), 0)
+		return nil
 	default:
 		return fmt.Errorf("wrong type")
 	}


### PR DESCRIPTION
Fixes https://github.com/neelance/graphql-go/issues/79 

This is super basic & probably needs some more work to 'type-check' custom scalars, but this at least gives the possibility of using things like Time as input arguments. Hopefully this PR can kickstart a more permanent fix.