### PR TITLE
Set content-type header to `application/json`

### DIFF
--- a/relay/relay.go
+++ b/relay/relay.go
@@ -2,12 +2,11 @@ package relay
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"strings"
-
-	"encoding/json"
 
 	graphql "github.com/neelance/graphql-go"
 )
@@ -66,5 +65,6 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	w.Header().Set("Content-Type", "application/json")
 	w.Write(responseJSON)
 }

--- a/relay/relay_test.go
+++ b/relay/relay_test.go
@@ -1,0 +1,36 @@
+package relay_test
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/neelance/graphql-go"
+	"github.com/neelance/graphql-go/example/starwars"
+	"github.com/neelance/graphql-go/relay"
+)
+
+var starwarsSchema = graphql.MustParseSchema(starwars.Schema, &starwars.Resolver{})
+
+func TestServeHTTP(t *testing.T) {
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/some/path/here", strings.NewReader(`{"query":"{ hero { name } }", "operationName":"", "variables": null}`))
+	h := relay.Handler{Schema: starwarsSchema}
+
+	h.ServeHTTP(w, r)
+
+	if w.Code != 200 {
+		t.Fatalf("Expected status code 200, got %d.", w.Code)
+	}
+
+	contentType := w.Header().Get("Content-Type")
+	if contentType != "application/json" {
+		t.Fatalf("Invalid content-type. Expected [application/json], but instead got [%s]", contentType)
+	}
+
+	expectedResponse := `{"data":{"hero":{"name":"R2-D2"}}}`
+	actualResponse := string(w.Body.Bytes())
+	if expectedResponse != actualResponse {
+		t.Fatalf("Invalid response. Expected [%s], but instead got [%s]", expectedResponse, actualResponse)
+	}
+}


### PR DESCRIPTION
This PR adds `Content-Type: application/json` header to the response of `relay.Handler`'s `ServerHTTP` method. 

I would like to submit more PRs to add some unit tests and improve the way `gqltesting` reports errors. For both of these I would like to add some dependencies like `github.com/stretchr/testify`. Do you have any dependency management tool preferences? I was thinking about `dep` or `glide`, WDYT?