### PR TITLE
Add `(*Schema).Validate`

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -122,7 +122,7 @@ type Response struct {
 	Extensions map[string]interface{} `json:"extensions,omitempty"`
 }
 
-// Validate validates the given query with the schema
+// Validate validates the given query with the schema.
 func (s *Schema) Validate(queryString string) []*errors.QueryError {
 	doc, qErr := query.Parse(queryString)
 	if qErr != nil {

--- a/graphql.go
+++ b/graphql.go
@@ -122,6 +122,16 @@ type Response struct {
 	Extensions map[string]interface{} `json:"extensions,omitempty"`
 }
 
+// Validate validates the given query with the schema
+func (s *Schema) Validate(queryString string) []*errors.QueryError {
+	doc, qErr := query.Parse(queryString)
+	if qErr != nil {
+		return []*errors.QueryError{qErr}
+	}
+
+	return validation.Validate(s.schema, doc)
+}
+
 // Exec executes the given query with the schema's resolver. It panics if the schema was created
 // without a resolver. If the context get cancelled, no further resolvers will be called and a
 // the context error will be returned as soon as possible (not immediately).


### PR DESCRIPTION
This adds a `Validate` method to the schema, which allows you to find out if a query is valid without actually running it. This is valuable when you have a client with static queries and want to statically determine whether they are valid.