### PR TITLE
Update GraphiQL UI

### DIFF
--- a/example/starwars/server/server.go
+++ b/example/starwars/server/server.go
@@ -33,17 +33,16 @@ var page = []byte(`
 <!DOCTYPE html>
 <html>
 	<head>
-		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/graphiql/0.7.8/graphiql.css" />
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/fetch/1.0.0/fetch.min.js"></script>
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.3.2/react.min.js"></script>
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.3.2/react-dom.min.js"></script>
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/graphiql/0.7.8/graphiql.js"></script>
+		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/graphiql/0.10.2/graphiql.css" />
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/fetch/1.1.0/fetch.min.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.5.4/react.min.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.5.4/react-dom.min.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/graphiql/0.10.2/graphiql.js"></script>
 	</head>
 	<body style="width: 100%; height: 100%; margin: 0; overflow: hidden;">
 		<div id="graphiql" style="height: 100vh;">Loading...</div>
 		<script>
 			function graphQLFetcher(graphQLParams) {
-				graphQLParams.variables = graphQLParams.variables ? JSON.parse(graphQLParams.variables) : null;
 				return fetch("/query", {
 					method: "post",
 					body: JSON.stringify(graphQLParams),

--- a/relay/relay_test.go
+++ b/relay/relay_test.go
@@ -29,7 +29,7 @@ func TestServeHTTP(t *testing.T) {
 	}
 
 	expectedResponse := `{"data":{"hero":{"name":"R2-D2"}}}`
-	actualResponse := string(w.Body.Bytes())
+	actualResponse := w.Body.String()
 	if expectedResponse != actualResponse {
 		t.Fatalf("Invalid response. Expected [%s], but instead got [%s]", expectedResponse, actualResponse)
 	}


### PR DESCRIPTION
This PR updates the GraphiQL UI in the example server. The most significant change is that it adds support for query history.