### PR TITLE
add built-in GraphiQL

### DIFF
--- a/example/starwars/server/server.go
+++ b/example/starwars/server/server.go
@@ -16,49 +16,12 @@ func init() {
 }
 
 func main() {
-	http.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write(page)
-	}))
-
-	http.Handle("/query", &relay.Handler{Schema: schema})
-
+	h := relay.New(&relay.Config{
+		Schema:   schema,
+		Pretty:   true,
+		GraphiQL: true,
+	})
+	// Endpoint can be set to anything, using `/graphiql` just for convention.
+	http.Handle("/graphiql", h)
 	log.Fatal(http.ListenAndServe(":8080", nil))
 }
-
-var page = []byte(`
-<!DOCTYPE html>
-<html>
-	<head>
-		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/graphiql/0.10.2/graphiql.css" />
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/fetch/1.1.0/fetch.min.js"></script>
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.5.4/react.min.js"></script>
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.5.4/react-dom.min.js"></script>
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/graphiql/0.10.2/graphiql.js"></script>
-	</head>
-	<body style="width: 100%; height: 100%; margin: 0; overflow: hidden;">
-		<div id="graphiql" style="height: 100vh;">Loading...</div>
-		<script>
-			function graphQLFetcher(graphQLParams) {
-				return fetch("/query", {
-					method: "post",
-					body: JSON.stringify(graphQLParams),
-					credentials: "include",
-				}).then(function (response) {
-					return response.text();
-				}).then(function (responseBody) {
-					try {
-						return JSON.parse(responseBody);
-					} catch (error) {
-						return responseBody;
-					}
-				});
-			}
-
-			ReactDOM.render(
-				React.createElement(GraphiQL, {fetcher: graphQLFetcher}),
-				document.getElementById("graphiql")
-			);
-		</script>
-	</body>
-</html>
-`)

--- a/example/starwars/server/server.go
+++ b/example/starwars/server/server.go
@@ -18,7 +18,6 @@ func init() {
 func main() {
 	h := relay.New(&relay.Config{
 		Schema:   schema,
-		Pretty:   true,
 		GraphiQL: true,
 	})
 	// Endpoint can be set to anything, using `/graphiql` just for convention.

--- a/relay/graphiql.go
+++ b/relay/graphiql.go
@@ -1,0 +1,195 @@
+package relay
+
+import (
+	"encoding/json"
+	"html/template"
+	"net/http"
+)
+
+// Page is the page data structure of the rendered GraphiQL page
+type graphiqlPage struct {
+	GraphiqlVersion string
+	QueryString     string
+	ResultString    string
+	VariablesString string
+	OperationName   string
+}
+
+func renderGraphiQL(w http.ResponseWriter, params param) {
+	t := template.New("GraphiQL")
+	t, err := t.Parse(graphiqlTemplate)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Create variables string
+	vars, err := json.MarshalIndent(params.VariablesValues, "", "  ")
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	varString := string(vars)
+	if varString == "null" {
+		varString = ""
+	}
+
+	// Create result string
+	var resString string
+	if params.RequestString == "" {
+		resString = ""
+	} else {
+		response, err := json.MarshalIndent(params.Schema.Exec(params.Context, params.RequestString, params.OperationName, params.VariablesValues), "", "  ")
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		resString = string(response)
+	}
+
+	p := graphiqlPage{
+		GraphiqlVersion: graphiqlVersion,
+		QueryString:     params.RequestString,
+		ResultString:    resString,
+		VariablesString: varString,
+		OperationName:   params.OperationName,
+	}
+	err = t.ExecuteTemplate(w, "index", p)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+	return
+}
+
+// graphiqlVersion is the current version of GraphiQL
+const graphiqlVersion = "0.11.3"
+
+// tmpl is the page template to render GraphiQL
+const graphiqlTemplate = `
+{{ define "index" }}
+<!--
+The request to this GraphQL server provided the header "Accept: text/html"
+and as a result has been presented GraphiQL - an in-browser IDE for
+exploring GraphQL.
+
+If you wish to receive JSON, provide the header "Accept: application/json" or
+add "&raw" to the end of the URL within a browser.
+-->
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>GraphiQL</title>
+  <meta name="robots" content="noindex" />
+  <style>
+    html, body {
+      height: 100%;
+      margin: 0;
+      overflow: hidden;
+      width: 100%;
+    }
+  </style>
+  <link href="//cdn.jsdelivr.net/npm/graphiql@{{ .GraphiqlVersion }}/graphiql.css" rel="stylesheet" />
+  <script src="//cdn.jsdelivr.net/fetch/0.9.0/fetch.min.js"></script>
+  <script src="//cdn.jsdelivr.net/react/15.4.2/react.min.js"></script>
+  <script src="//cdn.jsdelivr.net/react/15.4.2/react-dom.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/graphiql@{{ .GraphiqlVersion }}/graphiql.min.js"></script>
+</head>
+<body>
+  <script>
+    // Collect the URL parameters
+    var parameters = {};
+    window.location.search.substr(1).split('&').forEach(function (entry) {
+      var eq = entry.indexOf('=');
+      if (eq >= 0) {
+        parameters[decodeURIComponent(entry.slice(0, eq))] =
+          decodeURIComponent(entry.slice(eq + 1));
+      }
+    });
+
+    // Produce a Location query string from a parameter object.
+    function locationQuery(params) {
+      return '?' + Object.keys(params).filter(function (key) {
+        return Boolean(params[key]);
+      }).map(function (key) {
+        return encodeURIComponent(key) + '=' +
+          encodeURIComponent(params[key]);
+      }).join('&');
+    }
+
+    // Derive a fetch URL from the current URL, sans the GraphQL parameters.
+    var graphqlParamNames = {
+      query: true,
+      variables: true,
+      operationName: true
+    };
+
+    var otherParams = {};
+    for (var k in parameters) {
+      if (parameters.hasOwnProperty(k) && graphqlParamNames[k] !== true) {
+        otherParams[k] = parameters[k];
+      }
+    }
+    var fetchURL = locationQuery(otherParams);
+
+    // Defines a GraphQL fetcher using the fetch API.
+    function graphQLFetcher(graphQLParams) {
+      return fetch(fetchURL, {
+        method: 'post',
+        headers: {
+          'Accept': 'application/json',
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(graphQLParams),
+        credentials: 'include',
+      }).then(function (response) {
+        return response.text();
+      }).then(function (responseBody) {
+        try {
+          return JSON.parse(responseBody);
+        } catch (error) {
+          return responseBody;
+        }
+      });
+    }
+
+    // When the query and variables string is edited, update the URL bar so
+    // that it can be easily shared.
+    function onEditQuery(newQuery) {
+      parameters.query = newQuery;
+      updateURL();
+    }
+
+    function onEditVariables(newVariables) {
+      parameters.variables = newVariables;
+      updateURL();
+    }
+
+    function onEditOperationName(newOperationName) {
+      parameters.operationName = newOperationName;
+      updateURL();
+    }
+
+    function updateURL() {
+      history.replaceState(null, null, locationQuery(parameters));
+    }
+
+    // Render <GraphiQL /> into the body.
+    ReactDOM.render(
+      React.createElement(GraphiQL, {
+        fetcher: graphQLFetcher,
+        onEditQuery: onEditQuery,
+        onEditVariables: onEditVariables,
+        onEditOperationName: onEditOperationName,
+        query: {{ .QueryString }},
+        response: {{ .ResultString }},
+        variables: {{ .VariablesString }},
+        operationName: {{ .OperationName }},
+      }),
+      document.body
+    );
+  </script>
+</body>
+</html>
+{{ end }}
+`

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -1,11 +1,14 @@
 package relay
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"net/http"
+	"net/url"
 	"strings"
 
 	graphql "github.com/neelance/graphql-go"
@@ -43,28 +46,189 @@ func UnmarshalSpec(id graphql.ID, v interface{}) error {
 	return json.Unmarshal([]byte(s[i+1:]), v)
 }
 
+const (
+	ContentTypeJSON           = "application/json"
+	ContentTypeGraphQL        = "application/graphql"
+	ContentTypeFormURLEncoded = "application/x-www-form-urlencoded"
+)
+
 type Handler struct {
-	Schema *graphql.Schema
+	Schema   *graphql.Schema
+	pretty   bool
+	graphiql bool
+}
+
+type RequestOptions struct {
+	Query         string                 `json:"query" url:"query" schema:"query"`
+	Variables     map[string]interface{} `json:"variables" url:"variables" schema:"variables"`
+	OperationName string                 `json:"operationName" url:"operationName" schema:"operationName"`
+}
+
+// A workaround for getting `variables` as a JSON string
+type requestOptionsCompatibility struct {
+	Query         string `json:"query" url:"query" schema:"query"`
+	Variables     string `json:"variables" url:"variables" schema:"variables"`
+	OperationName string `json:"operationName" url:"operationName" schema:"operationName"`
+}
+
+func getFromForm(values url.Values) *RequestOptions {
+	query := values.Get("query")
+	if query != "" {
+		// get variables map
+		var variables map[string]interface{}
+		variablesStr := values.Get("variables")
+		json.Unmarshal([]byte(variablesStr), variables)
+
+		return &RequestOptions{
+			Query:         query,
+			Variables:     variables,
+			OperationName: values.Get("operationName"),
+		}
+	}
+	return nil
+}
+
+// NewRequestOptions Parses an http.Request into GraphQL request options struct
+func NewRequestOptions(r *http.Request) *RequestOptions {
+	if reqOpt := getFromForm(r.URL.Query()); reqOpt != nil {
+		return reqOpt
+	}
+
+	if r.Method != "POST" {
+		return &RequestOptions{}
+	}
+
+	if r.Body == nil {
+		return &RequestOptions{}
+	}
+
+	// TODO: improve Content-Type handling
+	contentTypeStr := r.Header.Get("Content-Type")
+	contentTypeTokens := strings.Split(contentTypeStr, ";")
+	contentType := contentTypeTokens[0]
+
+	switch contentType {
+	case ContentTypeGraphQL:
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			return &RequestOptions{}
+		}
+		return &RequestOptions{
+			Query: string(body),
+		}
+	case ContentTypeFormURLEncoded:
+		if err := r.ParseForm(); err != nil {
+			return &RequestOptions{}
+		}
+
+		if reqOpt := getFromForm(r.PostForm); reqOpt != nil {
+			return reqOpt
+		}
+
+		return &RequestOptions{}
+
+	case ContentTypeJSON:
+		fallthrough
+	default:
+		var opts RequestOptions
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			return &opts
+		}
+		err = json.Unmarshal(body, &opts)
+		if err != nil {
+			// Probably `variables` was sent as a string instead of an object.
+			// So, we try to be polite and try to parse that as a JSON string
+			var optsCompatible requestOptionsCompatibility
+			json.Unmarshal(body, &optsCompatible)
+			json.Unmarshal([]byte(optsCompatible.Variables), &opts.Variables)
+		}
+		return &opts
+	}
+}
+
+type param struct {
+	Schema          *graphql.Schema
+	RequestString   string
+	VariablesValues map[string]interface{}
+	OperationName   string
+	Context         context.Context
+}
+
+// ContextHandler provides an entrypoint into executing graphQL queries with a
+// user-provided context.
+func (h *Handler) ContextHandler(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+	// Gets Query
+	opts := NewRequestOptions(r)
+	params := param{
+		Schema:          h.Schema,
+		RequestString:   opts.Query,
+		VariablesValues: opts.Variables,
+		OperationName:   opts.OperationName,
+		Context:         ctx,
+	}
+	response := h.Schema.Exec(ctx, params.RequestString, params.OperationName, params.VariablesValues)
+
+	if h.graphiql {
+		acceptHeader := r.Header.Get("Accept")
+		_, raw := r.URL.Query()["raw"]
+		if !raw && !strings.Contains(acceptHeader, ContentTypeJSON) && strings.Contains(acceptHeader, "text/html") {
+			renderGraphiQL(w, params)
+			return
+		}
+	}
+
+	// Use proper JSON Header
+	w.Header().Add("Content-Type", "application/json; charset=utf-8")
+
+	if h.pretty {
+		w.WriteHeader(http.StatusOK)
+		responseJSON, err := json.MarshalIndent(response, "", "\t")
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Write(responseJSON)
+	} else {
+		w.WriteHeader(http.StatusOK)
+		responseJSON, err := json.Marshal(response)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Write(responseJSON)
+	}
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	var params struct {
-		Query         string                 `json:"query"`
-		OperationName string                 `json:"operationName"`
-		Variables     map[string]interface{} `json:"variables"`
+	h.ContextHandler(r.Context(), w, r)
+}
+
+type Config struct {
+	Schema   *graphql.Schema
+	Pretty   bool
+	GraphiQL bool
+}
+
+func NewConfig() *Config {
+	return &Config{
+		Schema:   nil,
+		Pretty:   true,
+		GraphiQL: true,
 	}
-	if err := json.NewDecoder(r.Body).Decode(&params); err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
+}
+
+func New(p *Config) *Handler {
+	if p == nil {
+		p = NewConfig()
+	}
+	if p.Schema == nil {
+		panic("Undefined GraphQL Schema")
 	}
 
-	response := h.Schema.Exec(r.Context(), params.Query, params.OperationName, params.Variables)
-	responseJSON, err := json.Marshal(response)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
+	return &Handler{
+		Schema:   p.Schema,
+		pretty:   p.Pretty,
+		graphiql: p.GraphiQL,
 	}
-
-	w.Header().Set("Content-Type", "application/json")
-	w.Write(responseJSON)
 }

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -54,7 +54,6 @@ const (
 
 type Handler struct {
 	Schema   *graphql.Schema
-	pretty   bool
 	graphiql bool
 }
 
@@ -180,24 +179,13 @@ func (h *Handler) ContextHandler(ctx context.Context, w http.ResponseWriter, r *
 
 	// Use proper JSON Header
 	w.Header().Add("Content-Type", ContentTypeJSON)
-
-	if h.pretty {
-		w.WriteHeader(http.StatusOK)
-		responseJSON, err := json.MarshalIndent(response, "", "\t")
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		w.Write(responseJSON)
-	} else {
-		w.WriteHeader(http.StatusOK)
-		responseJSON, err := json.Marshal(response)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		w.Write(responseJSON)
+	w.WriteHeader(http.StatusOK)
+	responseJSON, err := json.Marshal(response)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
+	w.Write(responseJSON)
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -206,14 +194,12 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 type Config struct {
 	Schema   *graphql.Schema
-	Pretty   bool
 	GraphiQL bool
 }
 
 func NewConfig() *Config {
 	return &Config{
 		Schema:   nil,
-		Pretty:   true,
 		GraphiQL: true,
 	}
 }
@@ -228,7 +214,6 @@ func New(p *Config) *Handler {
 
 	return &Handler{
 		Schema:   p.Schema,
-		pretty:   p.Pretty,
 		graphiql: p.GraphiQL,
 	}
 }

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -179,7 +179,7 @@ func (h *Handler) ContextHandler(ctx context.Context, w http.ResponseWriter, r *
 	}
 
 	// Use proper JSON Header
-	w.Header().Add("Content-Type", "application/json; charset=utf-8")
+	w.Header().Add("Content-Type", ContentTypeJSON)
 
 	if h.pretty {
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
I've been using [graphql-go/graphql](github.com/graphql-go/graphql) along with [graphql-go/handler](github.com/graphql-go/handler) for a while, until I found out this library, which is way less verbose (thanks for that).

Thing is They recently added built-in GraphiQL support, based on those changes I adapted them to this library, I've tested them on a project as well as in the star-wars example and they're working flawlessly.

This avoids declaring two endpoints, one for GraphiQL and the other one for `/query` and now it works (for both GraphiQL and queries) on a single user-declared endpoint.

~~Plus It now shows pretty JSON if set so.~~