### PR TITLE
Coerce integer ID scalar input

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -6,8 +6,6 @@ import (
 
 	"encoding/json"
 
-	"strconv"
-
 	"github.com/neelance/graphql-go/errors"
 	"github.com/neelance/graphql-go/internal/common"
 	"github.com/neelance/graphql-go/internal/exec"
@@ -20,27 +18,6 @@ import (
 	"github.com/neelance/graphql-go/log"
 	"github.com/neelance/graphql-go/trace"
 )
-
-// ID represents GraphQL's "ID" type. A custom type may be used instead.
-type ID string
-
-func (_ ID) ImplementsGraphQLType(name string) bool {
-	return name == "ID"
-}
-
-func (id *ID) UnmarshalGraphQL(input interface{}) error {
-	switch input := input.(type) {
-	case string:
-		*id = ID(input)
-		return nil
-	default:
-		return fmt.Errorf("wrong type")
-	}
-}
-
-func (id ID) MarshalJSON() ([]byte, error) {
-	return strconv.AppendQuote(nil, string(id)), nil
-}
 
 // ParseSchema parses a GraphQL schema and attaches the given root resolver. It returns an error if
 // the Go type signature of the resolvers does not match the schema. If nil is passed as the

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -1612,6 +1612,10 @@ func (r *inputResolver) Recursive(args struct{ Value *recursive }) int32 {
 	return n
 }
 
+func (r *inputResolver) ID(args struct{ Value graphql.ID }) graphql.ID {
+	return args.Value
+}
+
 func TestInput(t *testing.T) {
 	coercionSchema := graphql.MustParseSchema(`
 		schema {
@@ -1629,6 +1633,7 @@ func TestInput(t *testing.T) {
 			enum(value: Enum!): Enum!
 			nullableEnum(value: Enum): Enum
 			recursive(value: RecursiveInput!): Int!
+			id(value: ID!): ID!
 		}
 
 		input Input {
@@ -1664,6 +1669,8 @@ func TestInput(t *testing.T) {
 					nullableEnum1: nullableEnum(value: Option2)
 					nullableEnum2: nullableEnum(value: null)
 					recursive(value: {next: {next: {}}})
+					intID: id(value: 1234)
+					strID: id(value: "1234")
 				}
 			`,
 			ExpectedResult: `
@@ -1682,7 +1689,9 @@ func TestInput(t *testing.T) {
 					"enum": "Option2",
 					"nullableEnum1": "Option2",
 					"nullableEnum2": null,
-					"recursive": 3
+					"recursive": 3,
+					"intID": "1234",
+					"strID": "1234"
 				}
 			`,
 		},

--- a/id.go
+++ b/id.go
@@ -1,0 +1,30 @@
+package graphql
+
+import (
+	"errors"
+	"strconv"
+)
+
+// ID represents GraphQL's "ID" scalar type. A custom type may be used instead.
+type ID string
+
+func (_ ID) ImplementsGraphQLType(name string) bool {
+	return name == "ID"
+}
+
+func (id *ID) UnmarshalGraphQL(input interface{}) error {
+	var err error
+	switch input := input.(type) {
+	case string:
+		*id = ID(input)
+	case int32:
+		*id = ID(strconv.Itoa(int(input)))
+	default:
+		err = errors.New("wrong type")
+	}
+	return err
+}
+
+func (id ID) MarshalJSON() ([]byte, error) {
+	return strconv.AppendQuote(nil, string(id)), nil
+}

--- a/internal/common/literals.go
+++ b/internal/common/literals.go
@@ -22,7 +22,14 @@ type BasicLit struct {
 
 func (lit *BasicLit) Value(vars map[string]interface{}) interface{} {
 	switch lit.Type {
-	case scanner.Int, scanner.Float:
+	case scanner.Int:
+		value, err := strconv.ParseInt(lit.Text, 10, 32)
+		if err != nil {
+			panic(err)
+		}
+		return int32(value)
+
+	case scanner.Float:
 		value, err := strconv.ParseFloat(lit.Text, 64)
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
This change enables ID scalar inputs to be coerced from integer values as mentioned in the [October 2016 version of the GraphQL specification](http://facebook.github.io/graphql/October2016/#sec-ID).

> Input Coercion
> 
> When expected as an input type, any string (such as "4") or integer (such as 4) input value should be coerced to ID as appropriate for the ID formats a given GraphQL server expects. Any other input value, including float input values (such as 4.0), must raise a query error indicating an incorrect type.

This PR has is made up of the following changes:

- Add test cases for string and integer ID input
- Add a case to `ID.UnmarshalGraphQL` switch statement to handle coercion/unmarshalling integer input
- Move ID scalar implementation from `graphql.go` to its own file for neater code organization
- Separate `scanner.Int` and `scanner.Float` argument literal parsing cases