### PR TITLE
trace: Log graphql.variables rather than tag

### DIFF
--- a/trace/trace.go
+++ b/trace/trace.go
@@ -8,6 +8,7 @@ import (
 	"github.com/neelance/graphql-go/introspection"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
+	"github.com/opentracing/opentracing-go/log"
 )
 
 type TraceQueryFinishFunc func([]*errors.QueryError)
@@ -29,7 +30,7 @@ func (OpenTracingTracer) TraceQuery(ctx context.Context, queryString string, ope
 	}
 
 	if len(variables) != 0 {
-		span.SetTag("graphql.variables", variables)
+		span.LogFields(log.Object("graphql.variables", variables))
 	}
 
 	return spanCtx, func(errs []*errors.QueryError) {


### PR DESCRIPTION
According to the OT documentation tag values can be numeric types, strings, or
bools. The behavior of other tag value types is undefined at the OpenTracing
level. For example `github.com/lightstep/lightstep-tracer-go` generates error
events.